### PR TITLE
기본 옵션 status 적용

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,9 +16,9 @@ const mainCommand = define({
 })
 
 const args = process.argv.slice(2)
-const showHelp = args.length === 0
+const runStatus = args.length === 0
 
-await cli(showHelp ? ['--help'] : args, mainCommand, {
+await cli(runStatus ? ['status'] : args, mainCommand, {
   name: 'limitai',
   version: '0.1.9',
   description: 'LLM rate limit utilization monitor',


### PR DESCRIPTION
Closes #10

## Design Summary

<!-- codeai:analyze -->

The change is complete. Here's a summary of what was done:

### Change Summary

**File modified:** `src/cli.ts` (lines 19, 21)

| Before | After |
|--------|-------|
| `const showHelp = args.length === 0` | `const runStatus = args.length === 0` |
| `cli(showHelp ? ['--help'] : args, ...)` | `cli(runStatus ? ['status'] : args, ...)` |

**Behavior change:**
- `limitai` (no args) → now runs `status` command (was: showed `--help`)
- `limitai --help` → still shows help (unchanged)
- `limitai status` → still works explicitly (unchanged)
- All other subcommands → unchanged

---
*Generated by CodeAI from [issue #10](https://github.com/worktoolai/limitai/issues/10)*
