### PR TITLE
github action 오류 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/download-artifact@v4
         with:
@@ -75,9 +77,8 @@ jobs:
           NOTES=""
           if [ -n "$PREV_TAG" ]; then
             COMMITS=$(git log --oneline "${PREV_TAG}..${TAG}" --no-merges | sed 's/^/- /')
-            NOTES="${COMMITS}
-
-**Full Changelog**: [${PREV_TAG}...${TAG}](${REPO_URL}/compare/${PREV_TAG}...${TAG})"
+            CHANGELOG="**Full Changelog**: [${PREV_TAG}...${TAG}](${REPO_URL}/compare/${PREV_TAG}...${TAG})"
+            NOTES="$(printf '%s\n\n%s' "$COMMITS" "$CHANGELOG")"
           fi
 
           gh release create "$TAG" dist/* \


### PR DESCRIPTION
Closes #12

## Design Summary

<!-- codeai:analyze:revision -->

Now let me provide the updated analysis.

---

## 수정된 분석 결과

### 사용자 피드백 반영

> "버전 태그를 그대로 쓰는게 맞아 그런데 `No jobs were run`이 나오는건 이상한데?"

사용자 피드백에 따라 재분석한 결과, **이전 분석에서 `branches: [dev]` 추가와 `if: startsWith(...)` 조건은 불필요한 변경**이었습니다.

### 근본 원인: 하나의 YAML 구문 오류가 두 증상을 모두 유발

이슈에 보고된 두 가지 증상의 **원인은 동일**합니다:

**원본 코드 (line 78~80):**
```yaml
        run: |
          ...
            NOTES="${COMMITS}
                                    ← 빈 줄 (line 79)
**Full Changelog**: [${PREV_TAG}...${TAG}](...)"   ← line 80
```

YAML의 `|` (literal block scalar)에서 **빈 줄이 나오면 block의 끝으로 해석**됩니다. 따라서 line 80의 `**Full Changelog**`가 셸 스크립트가 아닌 YAML로 파싱되는데, `*`는 YAML에서 **alias 참조 문법**입니다. `*Full`이 유효한 alias가 아니므로 YAML 파서 오류가 발생합니다.

```
yaml.scanner.ScannerError: while scanning an alias
  in line 80, column 1
expected alphabetic or numeric character, but found '*'
  in line 80, column 2
```

- **증상 #1 (`No jobs were run`):** YAML 파싱 실패로 워크플로우의 jobs 정의를 읽을 수 없어 실행할 job이 없음
- **증상 #2 (`Invalid workflow file ... line 80`):** 동일한 YAML 구문 오류의 명시적 에러 메시지

### 수정 내용 (이전 대비 변경)

| 항목 | 이전 분석 | 수정 후 |
|------|-----------|---------|
| `branches: [dev]` 추가 | ✅ 추가 | ❌ **제거** — 트리거는 `tags: ['v*']`만으로 충분 |
| `if: startsWith(...)` 조건 | ✅ 추가 | ❌ **제거** — 태그 트리거만 있으므로 불필요 |
| YAML 구문 오류 수정 | ✅ printf로 변경 | ✅ 유지 |
| `fetch-depth: 0` 추가 | ✅ 추가 | ✅ 유지 |

### 최종 수정 사항 (2건만)

**1. YAML 구문 오류 수정 (line 78~80)**
```yaml
# 기존 (오류) — 빈 줄이 block scalar를 종료시켜 *가 YAML alias로 해석됨
NOTES="${COMMITS}

**Full Changelog**: ..."

# 수정 — printf로 빈 줄 포함 문자열 생성
CHANGELOG="**Full Changelog**: ..."
NOTES="$(printf '%s\n\n%s' "$COMMITS" "$CHANGELOG")"
```

**2. `fetch-depth: 0` 추가**
`release` job의 `actions/checkout`에 `fetch-depth: 0`을 추가하여 `git describe --tags`와 `git log`가 전체 히스토리에 접근할 수 있도록 합니다. (기본값은 shallow clone depth=1)

---
*Generated by CodeAI from [issue #12](https://github.com/worktoolai/limitai/issues/12)*
