### PR TITLE
github action 오류 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     tags: ['v*']
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -27,6 +32,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -50,6 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.tag || github.ref_name }}
           fetch-depth: 0
 
       - uses: actions/download-artifact@v4
@@ -57,9 +65,13 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Set tag name
+        id: tag
+        run: echo "name=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+
       - name: Validate tag matches package.json version
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${{ steps.tag.outputs.name }}"
           PKG_VERSION="v$(jq -r .version package.json)"
           if [ "$TAG" != "$PKG_VERSION" ]; then
             echo "::error::Tag ($TAG) does not match package.json version ($PKG_VERSION)"
@@ -70,7 +82,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${{ steps.tag.outputs.name }}"
           PREV_TAG=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || echo "")
           REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -12,6 +12,8 @@ jobs:
   version-bump:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -69,3 +71,11 @@ jobs:
           git tag "$TAG"
           git push origin dev
           git push origin "$TAG"
+
+  release:
+    needs: version-bump
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.version-bump.outputs.tag }}
+    permissions:
+      contents: write


### PR DESCRIPTION
Closes #16

## Design Summary

<!-- codeai:analyze -->

The changes look clean and correct. Let me provide the complete analysis:

---

## Issue Analysis & Fix

### 1. Summary

The issue reports that when a PR is merged into `dev`, the `version-bump.yml` workflow successfully bumps the version and pushes a tag (e.g., `v0.1.10`), but the `release.yml` workflow **never triggers**, so no GitHub Release is created.

### 2. Root Cause

**Pushes made using `secrets.GITHUB_TOKEN` (the default `GITHUB_TOKEN`) do NOT trigger other GitHub Actions workflows.** This is a [documented GitHub limitation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) designed to prevent recursive workflow triggers.

The flow was:
1. ✅ PR merged into `dev` → `version-bump.yml` triggers
2. ✅ Version bumped, committed, tag `v0.1.10` created and pushed
3. ❌ `release.yml` expects a `push: tags: ['v*']` event, but **GitHub suppresses this event** because the push was done with `GITHUB_TOKEN`

Additionally, the commit message contains `[skip ci]`, which further reinforces CI suppression.

### 3. Technical Fix

**Approach: Use `workflow_call` to chain the workflows directly.**

Instead of relying on the tag push event (which is suppressed), `version-bump.yml` now directly invokes `release.yml` using the `workflow_call` trigger after the version bump job completes.

#### Changes to `.github/workflows/release.yml`:
- Added `workflow_call` trigger with a `tag` input parameter
- Added explicit `ref` to `actions/checkout` steps using `${{ inputs.tag || github.ref_name }}` so the correct tag/commit is checked out regardless of how the workflow is invoked
- Replaced `${GITHUB_REF_NAME}` references with a step output that resolves `inputs.tag` (from `workflow_call`) or `github.ref_name` (from direct tag push), ensuring both trigger paths work correctly

#### Changes to `.github/workflows/version-bump.yml`:
- Added `outputs` section to the `version-bump` job to expose the `tag` value
- Added a new `release` job that calls `release.yml` via `uses: ./.github/workflows/release.yml` with the tag passed as input
- The `release` job depends on `version-bump` (`needs: version-bump`), so it only runs after the version bump and tag push succeed

### 4. How Both Trigger Paths Work

| Trigger | Flow |
|---------|------|
| **PR merge → `dev`** | `version-bump` → bumps version, pushes tag → `release` job calls `release.yml` via `workflow_call` with `inputs.tag` |
| **Manual tag push** | `release.yml` triggers directly via `push: tags: ['v*']`, uses `github.ref_name` (fallback from `inputs.tag || github.ref_name`) |

### 5. No Additional Secrets Required

This solution uses the existing `GITHUB_TOKEN` permissions. Unlike alternative approaches (using a PAT or GitHub App token), `workflow_call` works within the same workflow run context, so no additional repository secrets need to be configured.

---
*Generated by CodeAI from [issue #16](https://github.com/worktoolai/limitai/issues/16)*
